### PR TITLE
Parallel Testing

### DIFF
--- a/src/Attributes/ChatGPT.php
+++ b/src/Attributes/ChatGPT.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ArtisanBuild\Bench\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_ALL)]
+class ChatGPT {}


### PR DESCRIPTION
* Get parallel testing to work by creating a sqlite database for each core
* Add ChatGPT attribute to mark LLM-generated code